### PR TITLE
Rebuild with mkl v2025

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,5 @@
+mkl:
+  - 2025
 mpi:
   - nompi
   - mpich  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.9.0" %}
 {% set name = "arpack" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: {{ name|lower }}
@@ -15,7 +15,7 @@ build:
   # Arpack on win is built against mkl and nompi; Arpack on other archs is built against openblas and either nompi or mpich. 
   # osx-arm64 also uses openblas + openmpi combination in addition to nompi and mpich. 
   skip: true  # [not win and blas_impl == "mkl"]
-  # linux-ppc64le is switched off due to tests taking suspeciously long when run on prefect. 
+  # linux-ppc64le is switched off due to tests taking suspiciously long when run on prefect.
   skip: true  # [linux and ppc64le]
   # Per https://conda-forge.org/docs/maintainer/knowledge_base.html#preferring-a-provider-usually-nompi
   # add build string so packages can depend on
@@ -88,6 +88,8 @@ about:
   dev_url: https://github.com/opencollab/arpack-ng
 
 extra:
+  skip-lints:
+    - host_section_needs_exact_pinnings
   recipe-maintainers:
     - jschueller
     - mrakitin


### PR DESCRIPTION
arpack 3.9.0 b1

**Destination channel:** defaults

### Links

- [PKG-7085](https://anaconda.atlassian.net/browse/PKG-7085)
- [Upstream repository](https://github.com/opencollab/arpack-ng/tree/3.9.0)
- [Changelog](https://github.com/opencollab/arpack-ng/blob/3.9.0/CHANGES)
- Relevant dependency PRs:
  - AnacondaRecipes/intel_repack-feedstock#26
  - AnacondaRecipes/mkl-service-feedstock#6

### Explanation of changes:

- Bumped `mkl` version
- Silenced linter warning


[PKG-7085]: https://anaconda.atlassian.net/browse/PKG-7085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ