### PR TITLE
re-merge: arpack 3.9.0 b1 rebuild against openmpi 5

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,7 +50,6 @@ do
     -DBLA_VENDOR=OpenBLAS \
     -DBLAS_LIBRARIES="${OPENBLAS_LIB}" \
     -DLAPACK_LIBRARIES="${OPENBLAS_LIB}" \
-    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     ..
 
   # macOS: historical hack to strip '-fallow-argument-mismatch' from generated flags if present.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,6 +50,7 @@ do
     -DBLA_VENDOR=OpenBLAS \
     -DBLAS_LIBRARIES="${OPENBLAS_LIB}" \
     -DLAPACK_LIBRARIES="${OPENBLAS_LIB}" \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     ..
 
   # macOS: historical hack to strip '-fallow-argument-mismatch' from generated flags if present.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,9 +29,6 @@ if [[ ${HOST} =~ .*darwin.* ]]; then
   # Force CMake to use the Fortran compiler from the build env (not host env).
   export FC="${BUILD_PREFIX}/bin/${HOST}-gfortran"
   export CMAKE_Fortran_FLAGS="${FFLAGS}"
-  SAVED_CPP="$CPP"; SAVED_CPPFLAGS="$CPPFLAGS"
-  SAVED_CPATH="$CPATH"; SAVED_CIP="$C_INCLUDE_PATH"; SAVED_CPLUSIP="$CPLUS_INCLUDE_PATH"
-  unset CPP CPPFLAGS CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH
 fi
 
 # Tell CMake we want the OpenBLAS provider.
@@ -57,11 +54,6 @@ do
     -DBLAS_LIBRARIES="${OPENBLAS_LIB}" \
     -DLAPACK_LIBRARIES="${OPENBLAS_LIB}" \
     ..
-
-  if [[ ${HOST} =~ .*darwin.* ]]; then
-    export CPP="$SAVED_CPP"; export CPPFLAGS="$SAVED_CPPFLAGS"
-    export CPATH="$SAVED_CPATH"; export C_INCLUDE_PATH="$SAVED_CIP"; export CPLUS_INCLUDE_PATH="$SAVED_CPLUSIP"
-  fi
 
   # macOS: historical hack to strip '-fallow-argument-mismatch' from generated flags if present.
   # Guarded to avoid failing when these targets are not generated.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,6 +28,7 @@ fi
 if [[ ${HOST} =~ .*darwin.* ]]; then
   # Force CMake to use the Fortran compiler from the build env (not host env).
   export FC="${BUILD_PREFIX}/bin/${HOST}-gfortran"
+  export CMAKE_Fortran_FLAGS="${FFLAGS}"
 fi
 
 # Tell CMake we want the OpenBLAS provider.
@@ -38,6 +39,7 @@ OPENBLAS_LIB="${PREFIX}/lib/libopenblas${SHLIB_EXT}"
 for shared_libs in OFF ON
 do
   cmake ${CMAKE_ARGS} \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     -DCMAKE_Fortran_COMPILER="${FC}" \
     -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,6 +29,9 @@ if [[ ${HOST} =~ .*darwin.* ]]; then
   # Force CMake to use the Fortran compiler from the build env (not host env).
   export FC="${BUILD_PREFIX}/bin/${HOST}-gfortran"
   export CMAKE_Fortran_FLAGS="${FFLAGS}"
+  SAVED_CPP="$CPP"; SAVED_CPPFLAGS="$CPPFLAGS"
+  SAVED_CPATH="$CPATH"; SAVED_CIP="$C_INCLUDE_PATH"; SAVED_CPLUSIP="$CPLUS_INCLUDE_PATH"
+  unset CPP CPPFLAGS CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH
 fi
 
 # Tell CMake we want the OpenBLAS provider.
@@ -41,6 +44,7 @@ do
   cmake ${CMAKE_ARGS} \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     -DCMAKE_Fortran_COMPILER="${FC}" \
+    -DCMAKE_Fortran_FLAGS="${CMAKE_Fortran_FLAGS}" \
     -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DCMAKE_INSTALL_LIBDIR=lib \
@@ -53,6 +57,11 @@ do
     -DBLAS_LIBRARIES="${OPENBLAS_LIB}" \
     -DLAPACK_LIBRARIES="${OPENBLAS_LIB}" \
     ..
+
+  if [[ ${HOST} =~ .*darwin.* ]]; then
+    export CPP="$SAVED_CPP"; export CPPFLAGS="$SAVED_CPPFLAGS"
+    export CPATH="$SAVED_CPATH"; export C_INCLUDE_PATH="$SAVED_CIP"; export CPLUS_INCLUDE_PATH="$SAVED_CPLUSIP"
+  fi
 
   # macOS: historical hack to strip '-fallow-argument-mismatch' from generated flags if present.
   # Guarded to avoid failing when these targets are not generated.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Rationale summary:
 # - CMake couldn't find LAPACK → pass explicit BLAS/LAPACK = $PREFIX/lib/libopenblas${SHLIB_EXT} and set BLA_VENDOR=OpenBLAS.
@@ -8,7 +8,7 @@
 
 set -x
 
-mkdir build && cd build
+mkdir build && cd build || exit
 
 if [[ "$(echo $fortran_compiler_version | cut -d '.' -f 1)" -gt 9 ]]; then
   export FFLAGS="$FFLAGS -fallow-argument-mismatch"
@@ -16,7 +16,7 @@ fi
 
 if [[ ${HOST} =~ .*linux.* ]]; then
   # Need to point to libquadmath.so.0
-  export LD_LIBRARY_PATH=${PREFIX}/lib:$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH="${PREFIX}"/lib:"$LD_LIBRARY_PATH"
   # Exclude -fopenmp from build due to linking erorr resolution for libgomp
   # IMPORTANT: drop OpenMP from compile flags so we don't pull libgomp into runtime.
   # Our repo does not ship 'libgomp', and --error-overlinking will flag it if present.
@@ -28,7 +28,6 @@ fi
 if [[ ${HOST} =~ .*darwin.* ]]; then
   # Force CMake to use the Fortran compiler from the build env (not host env).
   export FC="${BUILD_PREFIX}/bin/${HOST}-gfortran"
-  export CMAKE_Fortran_FLAGS="${FFLAGS}"
 fi
 
 # Tell CMake we want the OpenBLAS provider.
@@ -39,15 +38,14 @@ OPENBLAS_LIB="${PREFIX}/lib/libopenblas${SHLIB_EXT}"
 for shared_libs in OFF ON
 do
   cmake ${CMAKE_ARGS} \
-    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-    -DCMAKE_Fortran_COMPILER="${FC}" \
-    -DCMAKE_Fortran_FLAGS="${CMAKE_Fortran_FLAGS}" \
-    -DCMAKE_PREFIX_PATH=${PREFIX} \
-    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DSKIP_FORTRAN_TRY_COMPILE=ON \
+    -DCMAKE_Fortran_COMPILER_WORKS=1 \
+    -DCMAKE_PREFIX_PATH="${PREFIX}" \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DBUILD_SHARED_LIBS=${shared_libs} \
     -DICB=ON \
-    -DMPI=${DMPI} \
+    -DMPI="${DMPI}" \
     -DTESTS=OFF \
     -DEXAMPLES=OFF \
     -DBLA_VENDOR=OpenBLAS \
@@ -63,12 +61,12 @@ do
       [ -f "$f" ] && sed -i '' 's/-fallow-argument-mismatch//g' "$f" || true
     done
   fi
-  make install -j${CPU_COUNT} VERBOSE=1
+  make install -j"${CPU_COUNT}" VERBOSE=1
 done
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
   # Do not run the test on osx as this test causes OS crashes on certain osx configurations.
-  if [[ ${HOST} =~ .*linux.* ]]; then
-    ctest --output-on-failure -j${CPU_COUNT}
+  if [[ "${HOST}" =~ .*linux.* ]]; then
+    ctest --output-on-failure -j"${CPU_COUNT}"
   fi
 fi

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,9 +6,16 @@ mpi:
   - nompi                  # [not (osx and arm64)]
   - mpich                  # [not (osx and arm64) and not win]
 
-c_compiler_version:        
-  - 15.2.0                 # [osx]
-cxx_compiler_version:      
-  - 15.2.0                 # [osx]
-fortran_compiler_version:  
-  - 15.2.0                 # [osx]
+c_compiler:
+  - clang                  # [osx]
+cxx_compiler:
+  - clangxx                # [osx]
+fortran_compiler:
+  - gfortran               # [osx]
+
+c_compiler_version:
+  - 20.1.8                 # [osx]
+cxx_compiler_version:
+  - 20.1.8                 # [osx]
+fortran_compiler_version:
+  - 14.3.0                 # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,3 +5,10 @@ mpi:
   - openmpi                # [osx and arm64]
   - nompi                  # [not (osx and arm64)]
   - mpich                  # [not (osx and arm64) and not win]
+
+c_compiler_version:        
+  - 15.2.0                 # [osx]
+cxx_compiler_version:      
+  - 15.2.0                 # [osx]
+fortran_compiler_version:  
+  - 15.2.0                 # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ build:
 
 requirements:
   build:
-    - cmake
+    - cmake >=3.3,<4.0
     - make  # [unix]
     - {{ compiler('fortran') }}  # [unix]
     - {{ compiler('c') }}  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -109,7 +109,6 @@ about:
 extra:
   skip-lints:
     - host_section_needs_exact_pinnings
-    - patch_unnecessary
   recipe-maintainers:
     - jschueller
     - mrakitin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -109,6 +109,7 @@ about:
 extra:
   skip-lints:
     - host_section_needs_exact_pinnings
+    - patch_unnecessary
   recipe-maintainers:
     - jschueller
     - mrakitin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ build:
 requirements:
   build:
     - cmake >=3.3,<4.0
+    - cmake >=4.0  # [osx]
     - make  # [unix]
     - {{ compiler('fortran') }}  # [unix]
     - {{ compiler('c') }}  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,12 +24,10 @@ build:
   # Arpack on win is built against mkl and nompi; Arpack on other archs is built against openblas and either nompi or mpich. 
   # osx-arm64 also uses openblas + openmpi combination in addition to nompi and mpich. 
   skip: true  # [not win and blas_impl == "mkl"]
-  # linux-ppc64le is switched off due to tests taking suspiciously long when run on prefect.
-  skip: true  # [linux and ppc64le]
   # Per https://conda-forge.org/docs/maintainer/knowledge_base.html#preferring-a-provider-usually-nompi
   # add build string so packages can depend on
   # mpi or nompi variants explicitly:
-
+  
   {% if mpi != 'nompi' %}
   {% set mpi_prefix = "mpi_" + mpi %}
   {% else %}
@@ -44,8 +42,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.3,<4.0
-    - cmake >=4.0  # [osx]
+    - cmake >=3.5,<4.0
     - make  # [unix]
     - {{ compiler('fortran') }}  # [unix]
     - {{ compiler('c') }}  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ requirements:
   build:
     - cmake >=3.5,<4.0
     - make  # [unix]
+    - {{ stdlib('c') }}     # [unix]
     - {{ compiler('fortran') }}  # [unix]
     - {{ compiler('c') }}  # [unix]
     - {{ compiler('cxx') }}  # [unix]

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,2 +1,0 @@
-# The build is failing without rsh available.
-rsh


### PR DESCRIPTION
arpack 3.9.0 b1

**Destination channel:** defaults

### Links

- [PKG-9130](https://anaconda.atlassian.net/browse/PKG-9130)
- [Upstream repository](https://github.com/opencollab/arpack-ng/tree/3.9.0)
- [Changelog](https://github.com/opencollab/arpack-ng/blob/3.9.0/CHANGES)

### Explanation of changes:

- rebuild against openmpi 5
- build.sh: changes to make osx build works
- conda_build_config.yaml: added clang/clangxx/gfortran with specific versions
- meta.yaml: removed ppc64le skip and fix cmake >=3.5

[PKG-9130]: https://anaconda.atlassian.net/browse/PKG-9130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ