### PR TITLE
arpack v3.9.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/openblas-feedstock/pr13/66809d1
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/63a47e9
-  - https://staging.continuum.io/pbp/fs/dsdp-feedstock/pr6/3f4f01b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/openblas-feedstock/pr13/66809d1
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/63a47e9
+  - https://staging.continuum.io/pbp/fs/dsdp-feedstock/pr6/3f4f01b

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,6 +13,8 @@ cmake -G "Ninja" ^
   -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX:\=/% ^
   -DBUILD_SHARED_LIBS=OFF ^
   -DICB=ON ^
+  -DTESTS=OFF ^
+  -DEXAMPLES=OFF ^
   -DBLA_VENDOR=%BLA_VENDOR% ^
   ..
 if errorlevel 1 exit 1
@@ -26,6 +28,8 @@ cmake -G "Ninja" ^
   -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX:\=/% ^
   -DBUILD_SHARED_LIBS=ON ^
   -DICB=ON ^
+  -DTESTS=OFF ^
+  -DEXAMPLES=OFF ^
   -DBLA_VENDOR=%BLA_VENDOR% ^
   ..
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,32 +1,34 @@
-
-: remove sh.exe from PATH
-set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
-set PATH=%PATH:C:\Program Files\Git\bin;=%
-
 mkdir build && cd build
+if errorlevel 1 exit 1
 
-:: Static build - configure.
-cmake -G "MinGW Makefiles" ^
-  -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX:\=/%/mingw-w64 ^
-  -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX:\=/%/mingw-w64 ^
+if "%blas_impl%"=="mkl" (
+  set "BLA_VENDOR=Intel10_64lp_seq"
+) else (
+  set "BLA_VENDOR=OpenBLAS"
+)
+
+:: Static build
+cmake -G "Ninja" ^
+  -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX:\=/% ^
+  -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX:\=/% ^
   -DBUILD_SHARED_LIBS=OFF ^
   -DICB=ON ^
+  -DBLA_VENDOR=%BLA_VENDOR% ^
   ..
 if errorlevel 1 exit 1
 
-:: Build.
-mingw32-make install -j %CPU_COUNT%
+ninja install -j %CPU_COUNT%
 if errorlevel 1 exit 1
 
-::  Shared build - configure.
-cmake -G "MinGW Makefiles" ^
-  -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX:\=/%/mingw-w64 ^
-  -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX:\=/%/mingw-w64 ^
+:: Shared build
+cmake -G "Ninja" ^
+  -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX:\=/% ^
+  -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX:\=/% ^
   -DBUILD_SHARED_LIBS=ON ^
   -DICB=ON ^
+  -DBLA_VENDOR=%BLA_VENDOR% ^
   ..
 if errorlevel 1 exit 1
 
-:: Build.
-mingw32-make install -j %CPU_COUNT%
+ninja install -j %CPU_COUNT%
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Rationale summary:
-# - CMake couldn't find LAPACK → pass explicit BLAS/LAPACK = $PREFIX/lib/libopenblas${SHLIB_EXT} and set BLA_VENDOR=OpenBLAS.
+# - BLA_VENDOR derived from $blas_impl variant; explicit BLAS/LAPACK paths only for OpenBLAS.
 # - --error-overlinking for libgomp → strip -fopenmp from *FLAGS and forbid finding OpenMP.
 # - macOS Fortran compiler ABI test failed → force FC from build env, remove f2c flags, add rpath to $PREFIX/lib.
 # - macOS overlinking to Accelerate/libcxx/llvm-openmp → don't add Accelerate; ignore run_exports for libcxx/llvm-openmp in meta.yaml.
@@ -30,10 +30,12 @@ if [[ ${HOST} =~ .*darwin.* ]]; then
   export FC="${BUILD_PREFIX}/bin/${HOST}-gfortran"
 fi
 
-# Tell CMake we want the OpenBLAS provider.
-export BLA_VENDOR=OpenBLAS
-# Pass the exact paths to BLAS/LAPACK to avoid FindLAPACK guessing (esp. under strict root paths).
-OPENBLAS_LIB="${PREFIX}/lib/libopenblas${SHLIB_EXT}"
+if [[ "${blas_impl}" == "mkl" ]]; then
+  BLAS_CMAKE_ARGS="-DBLA_VENDOR=Intel10_64lp_seq"
+else
+  OPENBLAS_LIB="${PREFIX}/lib/libopenblas${SHLIB_EXT}"
+  BLAS_CMAKE_ARGS="-DBLA_VENDOR=OpenBLAS -DBLAS_LIBRARIES=${OPENBLAS_LIB} -DLAPACK_LIBRARIES=${OPENBLAS_LIB}"
+fi
 
 for shared_libs in OFF ON
 do
@@ -48,9 +50,7 @@ do
     -DMPI="${DMPI}" \
     -DTESTS=OFF \
     -DEXAMPLES=OFF \
-    -DBLA_VENDOR=OpenBLAS \
-    -DBLAS_LIBRARIES="${OPENBLAS_LIB}" \
-    -DLAPACK_LIBRARIES="${OPENBLAS_LIB}" \
+    ${BLAS_CMAKE_ARGS} \
     ..
 
   # macOS: historical hack to strip '-fallow-argument-mismatch' from generated flags if present.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,16 +6,23 @@ mpi:
   - nompi                  # [not (osx and arm64)]
   - mpich                  # [not (osx and arm64) and not win]
 
-c_compiler:
-  - clang                  # [osx]
-cxx_compiler:
-  - clangxx                # [osx]
-fortran_compiler:
-  - gfortran               # [osx]
+numpy:
+  # python 3.10
+  - 2.4.4
+  # python 3.11
+  - 2.4.4
+  # python 3.12
+  - 2.4.4
+  # python 3.13
+  - 2.4.4
+  # python 3.14
+  - 2.4.4
 
-c_compiler_version:
-  - 20.1.8                 # [osx]
-cxx_compiler_version:
-  - 20.1.8                 # [osx]
+blas_impl:
+  - mkl                        # [(x86 or x86_64) and not osx]
+  - openblas
+
+fortran_compiler:
+  - flang             # [win]
 fortran_compiler_version:
-  - 14.3.0                 # [osx]
+  - 20                # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,18 +6,6 @@ mpi:
   - nompi                  # [not (osx and arm64)]
   - mpich                  # [not (osx and arm64) and not win]
 
-numpy:
-  # python 3.10
-  - 2.4.4
-  # python 3.11
-  - 2.4.4
-  # python 3.12
-  - 2.4.4
-  # python 3.13
-  - 2.4.4
-  # python 3.14
-  - 2.4.4
-
 blas_impl:
   - mkl                        # [(x86 or x86_64) and not osx]
   - openblas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@
 
 {% set version = "3.9.0" %}
 {% set name = "arpack" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 package:
   name: {{ name|lower }}
@@ -23,7 +23,7 @@ build:
   number: {{ build }}
   # Arpack on win is built against mkl and nompi; Arpack on other archs is built against openblas and either nompi or mpich. 
   # osx-arm64 also uses openblas + openmpi combination in addition to nompi and mpich. 
-  skip: true  # [not win and blas_impl == "mkl"]
+
   # Per https://conda-forge.org/docs/maintainer/knowledge_base.html#preferring-a-provider-usually-nompi
   # add build string so packages can depend on
   # mpi or nompi variants explicitly:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,9 @@
 #   than the one used by your current build environment.
 # To fix this, pin OpenBLAS to an older build from the 'defaults' channel that is compatible with your glibc version.
 
-{% set version = "3.9.0" %}
+{% set version = "3.9.1" %}
 {% set name = "arpack" %}
-{% set build = 4 %}
+{% set build = 0 %}
 
 package:
   name: {{ name|lower }}
@@ -17,7 +17,7 @@ package:
 
 source:
   url: https://github.com/opencollab/{{ name }}-ng/archive/{{ version }}.tar.gz
-  sha256: 24f2a2b259992d3c797d80f626878aa8e2ed5009d549dad57854bbcfb95e1ed0
+  sha256: f6641deb07fa69165b7815de9008af3ea47eb39b2bb97521fbf74c97aba6e844
 
 build:
   number: {{ build }}
@@ -80,10 +80,10 @@ test:
   commands:
     - test -f ${PREFIX}/lib/libarpack.a  # [unix]
     - test -f ${PREFIX}/lib/libarpack${SHLIB_EXT}  # [unix]
-    - test -f ${PREFIX}/include/arpack-ng/arpack.hpp  # [unix]
+    - test -f ${PREFIX}/include/arpack/arpack.hpp  # [unix]
     - if not exist %LIBRARY_LIB%\\arpack.lib exit 1  # [win]
     - if not exist %LIBRARY_BIN%\\arpack.dll exit 1  # [win]
-    - if not exist %LIBRARY_INC%\\arpack-ng\\arpack.hpp exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\arpack\\arpack.hpp exit 1  # [win]
 
 about:
   home: https://github.com/opencollab/arpack-ng

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
   build:
     - cmake >=3.5,<4.0
     - make  # [unix]
-    - ninja  # [win]
+    - ninja-base  # [win]
     - {{ stdlib('c') }}
     - {{ compiler('fortran') }}
     - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@
 
 {% set version = "3.9.0" %}
 {% set name = "arpack" %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 package:
   name: {{ name|lower }}
@@ -21,8 +21,8 @@ source:
 
 build:
   number: {{ build }}
-  # Arpack on win is built against mkl and nompi; Arpack on other archs is built against openblas and either nompi or mpich. 
-  # osx-arm64 also uses openblas + openmpi combination in addition to nompi and mpich. 
+  # Windows: mkl + openblas, nompi only. Unix: openblas (+ mkl on x86/x86_64 linux), nompi/mpich.
+  # osx-arm64 also uses openblas + openmpi in addition to nompi and mpich.
 
   # Per https://conda-forge.org/docs/maintainer/knowledge_base.html#preferring-a-provider-usually-nompi
   # add build string so packages can depend on
@@ -44,13 +44,11 @@ requirements:
   build:
     - cmake >=3.5,<4.0
     - make  # [unix]
-    - {{ stdlib('c') }}     # [unix]
-    - {{ compiler('fortran') }}  # [unix]
-    - {{ compiler('c') }}  # [unix]
-    - {{ compiler('cxx') }}  # [unix]
-    - {{ compiler('m2w64_fortran') }}  # [win]
-    - {{ compiler('m2w64_c') }}  # [win]
-    - {{ compiler('m2w64_cxx') }}  # [win]
+    - ninja  # [win]
+    - {{ stdlib('c') }}
+    - {{ compiler('fortran') }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - llvm-openmp  # [osx and not (blas_impl == "mkl")]
   host:
     # MPI/OpenMP
@@ -66,7 +64,6 @@ requirements:
     # IMPORTANT: use 'openblas' in host so headers + CMake config are available.
     - openblas {{ openblas }}  # [blas_impl == "openblas"]
   run:
-    - m2w64-gcc-libgfortran  # [win]
     # MPI/OpenMP
     - openmpi   # [mpi == 'openmpi']
     - {{ mpi }}              # [mpi == 'mpich']
@@ -84,10 +81,9 @@ test:
     - test -f ${PREFIX}/lib/libarpack.a  # [unix]
     - test -f ${PREFIX}/lib/libarpack${SHLIB_EXT}  # [unix]
     - test -f ${PREFIX}/include/arpack-ng/arpack.hpp  # [unix]
-    - if not exist %PREFIX%\\Library\\mingw-w64\\lib\\libarpack.a exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\mingw-w64\\lib\\libarpack.dll.a exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\mingw-w64\\bin\\libarpack.dll exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\mingw-w64\\include\\arpack-ng\\arpack.hpp exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\\arpack.lib exit 1  # [win]
+    - if not exist %LIBRARY_BIN%\\arpack.dll exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\arpack-ng\\arpack.hpp exit 1  # [win]
 
 about:
   home: https://github.com/opencollab/arpack-ng


### PR DESCRIPTION
arpack v3.9.1 with flang and openblas on windows. 

**Destination channel:** defaults

### Links

- [PKG-13580](https://anaconda.atlassian.net/browse/PKG-13580) 
- [Upstream repository](https://github.com/opencollab/arpack-ng/tree/3.9.1)
- [Upstream changelog/diff](https://github.com/opencollab/arpack-ng/blob/3.9.1/CHANGES#L28)

### Explanation of changes:

- Bump to v3.9.1
- Add openblas to build matrix for windows
- Switch to flang fortran compiler on windows
- Switch windows to use native compilers, get rid of `m2w64_*`
- Move includes from `arpack-ng` to `arpack` See https://github.com/opencollab/arpack-ng/blob/3.9.1/CHANGES#L18


[PKG-13580]: https://anaconda.atlassian.net/browse/PKG-13580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ